### PR TITLE
:recycle: Make checks async, add github annotations, merge eyo check to yaspeller

### DIFF
--- a/.github/problem-matchers/editor-config.json
+++ b/.github/problem-matchers/editor-config.json
@@ -1,0 +1,20 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "editor-config",
+            "pattern": [
+              {
+                "regexp": "^([^\\\\s].*)$",
+                "file": 1
+              },
+              {
+                "regexp": "^\\s+(\\d+):(\\d+)\\s(.+)$",
+                "line": 1,
+                "column": 2,
+                "message": 3,
+                "loop": true
+              }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/yaspeller.json
+++ b/.github/problem-matchers/yaspeller.json
@@ -1,0 +1,20 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "yaspeller",
+            "pattern": [
+              {
+                "regexp": "^✗\\s(.*)\\s\\d+\\sms$",
+                "file": 1
+              },
+              {
+                "regexp": "^\\d+\\. (.+) \\((\\d+):(\\d+).*$",
+                "message": 1,
+                "line": 2,
+                "column": 3,
+                "loop": true
+              }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/tlroadmap_workflow.yaml
+++ b/.github/workflows/tlroadmap_workflow.yaml
@@ -30,8 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Spell check
+        # problem matching breaks loop when it finds unrelated data, so we use reverse grep to clear output
         run: |
-          npx yaspeller -c .yaspellerrc.json .
+          echo "::add-matcher::.github/problem-matchers/yaspeller.json"
+          set -o pipefail; npx yaspeller -c .yaspellerrc.json . 2>&1 >/dev/null | grep -v "\-\-\-\-\-" | grep -v "Typos"
 
   editor-config:
     name: Editor Config check
@@ -39,14 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Editor Config Check
+        # problem matching breaks loop when it finds unrelated data, so we use reverse grep to clear output
         run: |
-          npx eclint check .
-
-  yo:
-    name: Ё check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Ё checks
-        run: |
-          npx eyo --only-safe --lint "**/*.md"
+          echo "::add-matcher::.github/problem-matchers/editor-config.json"
+          set -o pipefail; npx eclint check "**/*.md" 2>&1 >/dev/null | grep -v "EditorConfig"

--- a/.github/workflows/tlroadmap_workflow.yaml
+++ b/.github/workflows/tlroadmap_workflow.yaml
@@ -1,30 +1,52 @@
-name: TL Roadmap PR builder
+name: Checks
 
 on: [pull_request]
 
 jobs:
-  test:
-    name: Run all checks
+  readme-md:
+    name: README.md check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r tools/requirements.txt
-      - name: Spell checks
+
+      - name: README check
+        run: |
+          cd tools
+          bash check_readme.sh
+
+  yaspeller:
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Spell check
         run: |
           npx yaspeller -c .yaspellerrc.json .
-      - name: Linter check
+
+  editor-config:
+    name: Editor Config check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Editor Config Check
         run: |
           npx eclint check .
+
+  yo:
+    name: Ё check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Ё checks
         run: |
           npx eyo --only-safe --lint "**/*.md"
-      - name: README checks
-        run: |
-          cd tools && bash check_readme.sh

--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -9,6 +9,7 @@
   "ignoreUppercase": true,
   "ignoreUrls": true,
   "ignoreCapitalization": true,
+  "checkYo": true,
   "ignoreText": [
     ["– .*\\]", "g"],
     ["следующие люди:.*", "g"]


### PR DESCRIPTION
🎉 Теперь проверки асинхронные и не зависят друг от друга. Теперь не надо исправлять ошибки одного линтера и падать на следующем
![image](https://user-images.githubusercontent.com/19777948/80302955-d32d1980-87b5-11ea-9497-3cc0cc9ea4b2.png)

Добавлен problem-matching https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md

проверки на "ё" в CI теперь гоняются в yaspeller